### PR TITLE
Make it work

### DIFF
--- a/contracts/Forwarder.sol
+++ b/contracts/Forwarder.sol
@@ -16,7 +16,8 @@ contract Forwarder {
    * Default function; Gets called when Ether is deposited, and forwards it to the destination address
    */
   function() payable {
-    destinationAddress.send(msg.value);
+        if (!destinationAddress.send(msg.value))
+            throw;
   }
 
   /**
@@ -24,6 +25,7 @@ contract Forwarder {
    * We can flush those funds to the destination address.
    */
   function flush() {
-    destinationAddress.send(this.balance);
+    if (!destinationAddress.send(this.balance))
+          throw;
   }
 }

--- a/contracts/Forwarder.sol
+++ b/contracts/Forwarder.sol
@@ -1,3 +1,4 @@
+pragma solidity ^0.4.2;
 /**
  * Contract that will forward any incoming Ether to its creator
  */

--- a/contracts/Forwarder.sol
+++ b/contracts/Forwarder.sol
@@ -15,7 +15,7 @@ contract Forwarder {
   /**
    * Default function; Gets called when Ether is deposited, and forwards it to the destination address
    */
-  function() {
+  function() payable {
     destinationAddress.send(msg.value);
   }
 


### PR DESCRIPTION
Fixes the Forwarding contract.

Added:

- [x] Solidity version
- [x] Added `payable` to default contract function to allow the contract to send ETH
- [x] Added `throw` in case the contract is unable to send in order to remove the lower level function returning warning.

Deployed contract and sent ETH to it. Received the ETH through an internal transaction.
https://etherscan.io/address/0xd42ec8a7f97428041138cd61c0bd1926a481d95e