### PR TITLE
feat(contracts): add contract for recovery

### DIFF
--- a/recovery-contracts/CloneFactory.sol
+++ b/recovery-contracts/CloneFactory.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v4.8.0) (proxy/Clones.sol)
+pragma solidity 0.8.10;
+
+contract CloneFactory {
+
+function createClone(address implementation) internal returns (address payable instance) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Cleans the upper 96 bits of the `implementation` word, then packs the first 3 bytes
+            // of the `implementation` address with the bytecode before the address.
+            mstore(0x00, or(shr(0xe8, shl(0x60, implementation)), 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000))
+            // Packs the remaining 17 bytes of `implementation` with the bytecode after the address.
+            mstore(0x20, or(shl(0x78, implementation), 0x5af43d82803e903d91602b57fd5bf3))
+            instance := create(0, 0x09, 0x37)
+        }
+        require(instance != address(0), "ERC1167: create failed");
+    }
+}

--- a/recovery-contracts/RecoveryForwarder.sol
+++ b/recovery-contracts/RecoveryForwarder.sol
@@ -1,0 +1,60 @@
+pragma solidity 0.8.10;
+
+/**
+ * Basic singleSig contract designed to send funds controlled by signer.
+ */
+contract RecoveryForwarder {
+  // Address which can move funds from this contract
+  address public signer;
+  /**
+   * Initialize the signer
+   */
+  function init(address _signer) external onlyUninitialized {
+    signer = _signer;
+  }
+
+   /**
+   * Modifier that will execute internal code block only if the sender is an authorized signer on this wallet
+   */
+  modifier onlySigner {
+    require( signer == msg.sender, 'Non-signer in onlySigner method');
+    _;
+  }
+
+  /**
+   * Modifier that will execute internal code block only if the contract has not been initialized yet
+   */
+  modifier onlyUninitialized {
+    require(signer == address(0x0), 'Already initialized');
+    _;
+  }
+
+   /**
+   * Default function; Gets called when Ether is deposited
+   */
+   receive() external payable {
+  }
+
+  /**
+   * Default function; Gets called when data is sent but does not match any other function
+   */
+  fallback() external payable {
+  }
+
+  /**
+   * Execute a transaction from this contract using the signer.
+   *
+   * @param toAddress the destination address to send an outgoing transaction
+   * @param value the amount in Wei to be sent
+   * @param data the data to send to the toAddress when invoking the transaction
+   */
+  function sendFunds(
+      address toAddress,
+      uint256 value,
+      bytes calldata data
+  ) external onlySigner {
+    // Success, send the transaction
+   (bool success, ) = toAddress.call{ value: value }(data);
+    require(success, 'Call execution failed');
+  }
+}

--- a/recovery-contracts/RecoveryWallet.sol
+++ b/recovery-contracts/RecoveryWallet.sol
@@ -1,0 +1,70 @@
+pragma solidity 0.8.10;
+import "./RecoveryForwarder.sol";
+import "./CloneFactory.sol";
+/**
+ *
+ * RecoveryWallet
+ * ============
+ *
+ * Basic singleSig wallet designed to recover funds.
+ *
+ */
+contract RecoveryWallet is CloneFactory {
+
+  // Public fields
+  address public immutable signer;
+  address public immutable forwarderImplementationAddress;
+
+  constructor (address _signer, address _forwarderImplementationAddress) {
+    signer = _signer;
+    forwarderImplementationAddress = _forwarderImplementationAddress;
+  }
+  /**
+   * Modifier that will execute internal code block only if the sender is an authorized signer on this wallet
+   */
+  modifier onlySigner {
+    require( signer == msg.sender, 'Non-signer in onlySigner method');
+    _;
+  }
+
+  /**
+   * Gets called when a transaction is received with ether and no data
+   */
+  receive() external payable {
+  }
+  /**
+   * Default function; Gets called when data is sent but does not match any other function
+   */
+  fallback() external payable {
+  }
+
+  /**
+   * Creates new forwarder contract controlled by signer in batches
+   */
+function createRecoveryForwarder(uint8 value) external {
+    require(value > 0 && value < 150 , 'value must be greater than 0 and less than 150');
+    for ( uint8 i = 0; i < value; ++i) {
+    address payable clone = createClone(forwarderImplementationAddress);
+    RecoveryForwarder(clone).init(signer);
+    }
+  } 
+
+  /**
+   * Execute a transaction from this wallet using the signer.
+   *
+   * @param toAddress the destination address to send an outgoing transaction
+   * @param value the amount in Wei to be sent
+   * @param data the data to send to the toAddress when invoking the transaction
+   */
+  function sendFunds(
+      address toAddress,
+      uint256 value,
+      bytes calldata data
+  ) external onlySigner {
+
+    // Success, send the transaction
+   (bool success, ) = toAddress.call{ value: value }(data);
+    require(success, 'Call execution failed');
+  }
+  
+}


### PR DESCRIPTION
Ticket: BG-62483
We want to create lightweight contracts to help with cross chain recovery for evm like chains
These contracts consume less gas usage to deploy and are easier to recover funds due to singleSig nature
GasUsage (updated) -------old. -----new
WalletSimple  --------------900k ----340k
Forwarder   ---------------- 240k -----88k(70k if done in batches)