### PR TITLE
feat(contracts): make v0 contracts similar to v1

### DIFF
--- a/recovery-contracts/ERC20Interface.sol
+++ b/recovery-contracts/ERC20Interface.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+
+/**
+ * Contract that exposes the needed erc20 token functions
+ */
+
+abstract contract ERC20Interface {
+  // Send _value amount of tokens to address _to
+  function transfer(address _to, uint256 _value)
+    public
+    virtual
+    returns (bool success);
+
+  // Get the account balance of another account with address _owner
+  function balanceOf(address _owner)
+    public
+    virtual
+    view
+    returns (uint256 balance);
+}

--- a/recovery-contracts/RecoveryForwarder.sol
+++ b/recovery-contracts/RecoveryForwarder.sol
@@ -1,23 +1,24 @@
 pragma solidity 0.8.10;
-
+import './TransferHelper.sol';
+import './ERC20Interface.sol';
 /**
- * Basic singleSig contract designed to send funds controlled by signer.
+ * Contract that will forward any incoming Ether to the creator of the contract
  */
 contract RecoveryForwarder {
-  // Address which can move funds from this contract
-  address public signer;
+  // Address to which any funds sent to this contract will be forwarded
+  address public parentAddress;
   /**
-   * Initialize the signer
+   * Initialize the parent
    */
-  function init(address _signer) external onlyUninitialized {
-    signer = _signer;
+  function init(address _parentAddress) external onlyUninitialized {
+    parentAddress = _parentAddress;
   }
 
-   /**
-   * Modifier that will execute internal code block only if the sender is an authorized signer on this wallet
-   */
-  modifier onlySigner {
-    require( signer == msg.sender, 'Non-signer in onlySigner method');
+  /**
+  * Modifier that will execute internal code block only if the sender is the parent address
+  */
+  modifier onlyParent {
+    require( parentAddress == msg.sender, 'Non-parent in onlyParent method');
     _;
   }
 
@@ -25,36 +26,59 @@ contract RecoveryForwarder {
    * Modifier that will execute internal code block only if the contract has not been initialized yet
    */
   modifier onlyUninitialized {
-    require(signer == address(0x0), 'Already initialized');
+    require(parentAddress == address(0x0), 'Already initialized');
     _;
   }
 
-   /**
-   * Default function; Gets called when Ether is deposited
-   */
-   receive() external payable {
+  /**
+  * Default function; Gets called when Ether is deposited
+  */
+  receive() external payable {
+    flush();
   }
 
   /**
    * Default function; Gets called when data is sent but does not match any other function
    */
   fallback() external payable {
+    flush();
   }
 
   /**
-   * Execute a transaction from this contract using the signer.
-   *
-   * @param toAddress the destination address to send an outgoing transaction
-   * @param value the amount in Wei to be sent
-   * @param data the data to send to the toAddress when invoking the transaction
+   * Execute a token transfer of the full balance from the forwarder token to the parent address
+   * @param tokenContractAddress the address of the erc20 token contract
    */
-  function sendFunds(
-      address toAddress,
-      uint256 value,
-      bytes calldata data
-  ) external onlySigner {
-    // Success, send the transaction
-   (bool success, ) = toAddress.call{ value: value }(data);
-    require(success, 'Call execution failed');
+  function flushTokens(address tokenContractAddress) external onlyParent {
+    ERC20Interface instance = ERC20Interface(tokenContractAddress);
+    address forwarderAddress = address(this);
+    uint256 forwarderBalance = instance.balanceOf(forwarderAddress);
+    TransferHelper.safeTransfer(
+      tokenContractAddress,
+      parentAddress,
+      forwarderBalance
+    );
+  }
+
+  /**
+   * A fallback function which can used to transfer funds controlled by parent.
+   */
+  function callFromParent(
+  address target,
+  uint256 value,
+  bytes calldata data
+  ) external onlyParent {
+    (bool success, ) = target.call{ value: value }(
+      data
+    );
+    require(success, 'Parent call execution failed');
+  }
+
+  /**
+   * Flush the entire balance of the contract to the parent address.
+   */
+  function flush() public {
+    uint256 value = address(this).balance;
+    (bool success, ) = parentAddress.call{ value: value }('');
+    require(success, 'Flush failed');
   }
 }

--- a/recovery-contracts/RecoveryWallet.sol
+++ b/recovery-contracts/RecoveryWallet.sol
@@ -41,13 +41,28 @@ contract RecoveryWallet is CloneFactory {
   /**
    * Creates new forwarder contract controlled by signer in batches
    */
-function createRecoveryForwarder(uint8 value) external {
+  function createRecoveryForwarder(uint8 value) external {
     require(value > 0 && value < 150 , 'value must be greater than 0 and less than 150');
     for ( uint8 i = 0; i < value; ++i) {
     address payable clone = createClone(forwarderImplementationAddress);
-    RecoveryForwarder(clone).init(signer);
+    RecoveryForwarder(clone).init(address(this));
     }
   } 
+
+  /**
+   * Execute a token flush from one of the forwarder addresses. This transfer needs only a single signature and can be done by any signer
+   *
+   * @param forwarderAddress the address of the forwarder address to flush the tokens from
+   * @param tokenContractAddress the address of the erc20 token contract
+   */
+  function flushForwarderTokens(
+    address payable forwarderAddress, 
+    address tokenContractAddress
+  ) external {
+    RecoveryForwarder forwarder = RecoveryForwarder(forwarderAddress);
+    forwarder.flushTokens(tokenContractAddress);
+  }
+
 
   /**
    * Execute a transaction from this wallet using the signer.
@@ -66,5 +81,4 @@ function createRecoveryForwarder(uint8 value) external {
    (bool success, ) = toAddress.call{ value: value }(data);
     require(success, 'Call execution failed');
   }
-  
 }

--- a/recovery-contracts/TransferHelper.sol
+++ b/recovery-contracts/TransferHelper.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// source: https://github.com/Uniswap/solidity-lib/blob/master/contracts/libraries/TransferHelper.sol
+pragma solidity 0.8.10;
+
+// helper methods for interacting with ERC20 tokens and sending ETH that do not consistently return true/false
+library TransferHelper {
+  function safeTransfer(
+    address token,
+    address to,
+    uint256 value
+  ) internal {
+    // bytes4(keccak256(bytes('transfer(address,uint256)')));
+    (bool success, bytes memory data) = token.call(
+      abi.encodeWithSelector(0xa9059cbb, to, value)
+    );
+    require(
+      success && (data.length == 0 || abi.decode(data, (bool))),
+      'TransferHelper::safeTransfer: transfer failed'
+    );
+  }
+}


### PR DESCRIPTION
Ticket: BG-62483
Earlier for recovery contracts we have enabled sending funds directly from v0 forwarder without having to flush however we cannot do the same with v1/v2 forwarder. Therefore to remain consistent we first flush the token/coin and then send from base address.

The GasUsage for wallet deployment is increased from 350k to 386k however for forwarder deployment there is no chance its still 89k

Changes:
1. Added flushTokens in wallet contract
2. Make changes to forwarder such that its very similar to v0 forwarder